### PR TITLE
Permit to override which zlib library is linked

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@
 
 cmake_minimum_required(VERSION 3.14.6)
 
+# This is normally set by project(), but it's needed by options.cmake
+# which is called before that.
+set(PROJECT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+
 include("cmake/options.cmake")
 include("cmake/sanitizers.cmake")
 include("cmake/utils.cmake")

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -46,4 +46,7 @@ else()
 endif()
 
 option(EBPF_COMMON_ENABLE_LIBCPP "Set to ON to build with libc++" ${default_libcpp_setting})
-set(EBPF_COMMON_ZLIB_LIBRARY_PATH "" CACHE FILEPATH "Specifies the path of the zlib library file to use. If left empty the system one will be used")
+
+if("${PROJECT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
+  set(EBPF_COMMON_ZLIB_LIBRARY_PATH "" CACHE FILEPATH "Specifies the path of the zlib library file to use. If left empty the system one will be used")
+endif()

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -46,3 +46,4 @@ else()
 endif()
 
 option(EBPF_COMMON_ENABLE_LIBCPP "Set to ON to build with libc++" ${default_libcpp_setting})
+set(EBPF_COMMON_ZLIB_LIBRARY_PATH "" CACHE FILEPATH "Specifies the path of the zlib library file to use. If left empty the system one will be used")

--- a/libraries/LLVM/CMakeLists.txt
+++ b/libraries/LLVM/CMakeLists.txt
@@ -38,33 +38,46 @@ function(ebpfCommonLibrariesLLVM)
     # some ebpfpub users want to be able to override this, to avoid using the system one.
     # We therefore list all the library targets that the user of ebpf-common will end up linking,
     # and remove any reference to "z" or "-lz" and use the one specified in EBPF_COMMON_ZLIB_LIBRARY
-
-    if(NOT EXISTS "${EBPF_COMMON_ZLIB_LIBRARY_PATH}")
-      message(FATAL_ERROR "The path specified in EBPF_COMMON_ZLIB_LIBRARY_PATH does not exist")
-    endif()
-
-    message(STATUS: "Overriding zlib library with: ${EBPF_COMMON_ZLIB_LIBRARY_PATH}")
+    message(STATUS "ebpf-common - Overriding zlib library with: ${EBPF_COMMON_ZLIB_LIBRARY_PATH}")
 
     # This is an LLVM CMake helper function which lists all the library targets that the user will end up linking against
     explicit_map_components_to_libraries(llvm_full_library_list ${llvm_component_list})
 
     foreach(llvm_library ${llvm_full_library_list})
-      get_target_property(INTERFACE_LINK_OPTIONS ${llvm_library} INTERFACE_LINK_OPTIONS)
-      get_target_property(INTERFACE_LINK_LIBRARIES ${llvm_library} INTERFACE_LINK_LIBRARIES)
+      get_target_property(interface_link_options ${llvm_library} INTERFACE_LINK_OPTIONS)
+      get_target_property(interface_link_libraries ${llvm_library} INTERFACE_LINK_LIBRARIES)
 
-      if(NOT "${INTERFACE_LINK_OPTIONS}" STREQUAL "INTERFACE_LINK_OPTIONS-NOTFOUND")
-        list(REMOVE_ITEM INTERFACE_LINK_OPTIONS "-lz" ${INTERFACE_LINK_OPTIONS})
-        set_target_properties(${llvm_library} PROPERTIES INTERFACE_LINK_OPTIONS ${INTERFACE_LINK_OPTIONS})
+      if(NOT "${interface_link_options}" STREQUAL "interface_link_options-NOTFOUND")
+        list(FIND interface_link_options "-lz" libz_pos)
+
+        if (NOT ${libz_pos} EQUAL -1)
+          list(REMOVE_ITEM interface_link_options "-lz")
+          set_target_properties(${llvm_library} PROPERTIES INTERFACE_LINK_OPTIONS ${interface_link_options})
+        endif()
       endif()
 
-      if(NOT "${INTERFACE_LINK_LIBRARIES}" STREQUAL "INTERFACE_LINK_LIBRARIES-NOTFOUND")
-        message(STATUS "Library ${llvm_library} starting with: ${INTERFACE_LINK_LIBRARIES}")
-        list(REMOVE_ITEM INTERFACE_LINK_LIBRARIES "z")
-        list(REMOVE_ITEM INTERFACE_LINK_LIBRARIES "-lz")
-        list(APPEND INTERFACE_LINK_LIBRARIES "${EBPF_COMMON_ZLIB_LIBRARY_PATH}")
-        set_target_properties(${llvm_library} PROPERTIES INTERFACE_LINK_LIBRARIES "${INTERFACE_LINK_LIBRARIES}")
-      endif()
+      if(NOT "${interface_link_libraries}" STREQUAL "interface_link_libraries-NOTFOUND")
+        set(substitute_zlib FALSE)
 
+        list(FIND interface_link_libraries "z" libz_pos)
+
+        if (NOT ${libz_pos} EQUAL -1)
+          set(substitute_zlib TRUE)
+          list(REMOVE_ITEM interface_link_libraries "z")
+        endif()
+
+        list(FIND interface_link_libraries "-lz" libz_pos)
+
+        if (NOT ${libz_pos} EQUAL -1)
+          set(substitute_zlib TRUE)
+          list(REMOVE_ITEM interface_link_libraries "-lz")
+        endif()
+
+        if(substitute_zlib)
+          list(APPEND interface_link_libraries "${EBPF_COMMON_ZLIB_LIBRARY_PATH}")
+          set_target_properties(${llvm_library} PROPERTIES INTERFACE_LINK_LIBRARIES "${interface_link_libraries}")
+        endif()
+      endif()
     endforeach()
   endif()
 

--- a/libraries/LLVM/CMakeLists.txt
+++ b/libraries/LLVM/CMakeLists.txt
@@ -43,6 +43,8 @@ function(ebpfCommonLibrariesLLVM)
       message(FATAL_ERROR "The path specified in EBPF_COMMON_ZLIB_LIBRARY_PATH does not exist")
     endif()
 
+    message(STATUS: "Overriding zlib library with: ${EBPF_COMMON_ZLIB_LIBRARY_PATH}")
+
     # This is an LLVM CMake helper function which lists all the library targets that the user will end up linking against
     explicit_map_components_to_libraries(llvm_full_library_list ${llvm_component_list})
 
@@ -53,7 +55,6 @@ function(ebpfCommonLibrariesLLVM)
       if(NOT "${INTERFACE_LINK_OPTIONS}" STREQUAL "INTERFACE_LINK_OPTIONS-NOTFOUND")
         list(REMOVE_ITEM INTERFACE_LINK_OPTIONS "-lz" ${INTERFACE_LINK_OPTIONS})
         set_target_properties(${llvm_library} PROPERTIES INTERFACE_LINK_OPTIONS ${INTERFACE_LINK_OPTIONS})
-        message(STATUS "Library ${llvm_library} setting options: ${INTERFACE_LINK_OPTIONS}")
       endif()
 
       if(NOT "${INTERFACE_LINK_LIBRARIES}" STREQUAL "INTERFACE_LINK_LIBRARIES-NOTFOUND")
@@ -62,7 +63,6 @@ function(ebpfCommonLibrariesLLVM)
         list(REMOVE_ITEM INTERFACE_LINK_LIBRARIES "-lz")
         list(APPEND INTERFACE_LINK_LIBRARIES "${EBPF_COMMON_ZLIB_LIBRARY_PATH}")
         set_target_properties(${llvm_library} PROPERTIES INTERFACE_LINK_LIBRARIES "${INTERFACE_LINK_LIBRARIES}")
-        message(STATUS "Library ${llvm_library} setting libraries: ${INTERFACE_LINK_LIBRARIES}")
       endif()
 
     endforeach()

--- a/libraries/LLVM/CMakeLists.txt
+++ b/libraries/LLVM/CMakeLists.txt
@@ -33,6 +33,41 @@ function(ebpfCommonLibrariesLLVM)
     ${llvm_component_list}
   )
 
+  if(NOT EBPF_COMMON_ZLIB_LIBRARY_PATH STREQUAL "")
+    # This is a bit of a hack. The LLVM libraries want to link against a shared version of libz,
+    # some ebpfpub users want to be able to override this, to avoid using the system one.
+    # We therefore list all the library targets that the user of ebpf-common will end up linking,
+    # and remove any reference to "z" or "-lz" and use the one specified in EBPF_COMMON_ZLIB_LIBRARY
+
+    if(NOT EXISTS "${EBPF_COMMON_ZLIB_LIBRARY_PATH}")
+      message(FATAL_ERROR "The path specified in EBPF_COMMON_ZLIB_LIBRARY_PATH does not exist")
+    endif()
+
+    # This is an LLVM CMake helper function which lists all the library targets that the user will end up linking against
+    explicit_map_components_to_libraries(llvm_full_library_list ${llvm_component_list})
+
+    foreach(llvm_library ${llvm_full_library_list})
+      get_target_property(INTERFACE_LINK_OPTIONS ${llvm_library} INTERFACE_LINK_OPTIONS)
+      get_target_property(INTERFACE_LINK_LIBRARIES ${llvm_library} INTERFACE_LINK_LIBRARIES)
+
+      if(NOT "${INTERFACE_LINK_OPTIONS}" STREQUAL "INTERFACE_LINK_OPTIONS-NOTFOUND")
+        list(REMOVE_ITEM INTERFACE_LINK_OPTIONS "-lz" ${INTERFACE_LINK_OPTIONS})
+        set_target_properties(${llvm_library} PROPERTIES INTERFACE_LINK_OPTIONS ${INTERFACE_LINK_OPTIONS})
+        message(STATUS "Library ${llvm_library} setting options: ${INTERFACE_LINK_OPTIONS}")
+      endif()
+
+      if(NOT "${INTERFACE_LINK_LIBRARIES}" STREQUAL "INTERFACE_LINK_LIBRARIES-NOTFOUND")
+        message(STATUS "Library ${llvm_library} starting with: ${INTERFACE_LINK_LIBRARIES}")
+        list(REMOVE_ITEM INTERFACE_LINK_LIBRARIES "z")
+        list(REMOVE_ITEM INTERFACE_LINK_LIBRARIES "-lz")
+        list(APPEND INTERFACE_LINK_LIBRARIES "${EBPF_COMMON_ZLIB_LIBRARY_PATH}")
+        set_target_properties(${llvm_library} PROPERTIES INTERFACE_LINK_LIBRARIES "${INTERFACE_LINK_LIBRARIES}")
+        message(STATUS "Library ${llvm_library} setting libraries: ${INTERFACE_LINK_LIBRARIES}")
+      endif()
+
+    endforeach()
+  endif()
+
   add_library(thirdparty_llvm INTERFACE)
   target_link_libraries(thirdparty_llvm INTERFACE ${llvm_library_list})
 


### PR DESCRIPTION
Add the EBPF_COMMON_ZLIB_LIBRARY_PATH option
so that the user can specify the path to an alternative zlib library,
instead of linking the system one.

This is for instance needed for osquery,
where the project wants/needs to use its own version
instead of the system one.